### PR TITLE
Update App.vue

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -29,25 +29,19 @@ const getRotations = (num = 20) => Array(num).fill().map(() => [random(), random
 export default {
   name: 'SphereVue',
   data: () => ({
-    renderer: Object.create(null),
     fps: 0,
     count: 20,
     rotations: getRotations(),
   }),
-  created() {
-    const handleAnimation = () => {
-      const { element } = this.$refs
-      this.renderer = new WebGlHelper({
-        container: element,
-        onFPSUpdate: fps => this.fps = fps,
-      });
+  mounted() {
+    const { element } = this.$refs
+    this.renderer = new WebGlHelper({
+      container: element,
+      onFPSUpdate: fps => this.fps = fps,
+    });
 
-      this.renderer.animate();
-      this.renderer.syncBoxes(this.rotations);
-    };
-
-
-    this.$nextTick(handleAnimation);
+    this.renderer.animate();
+    this.renderer.syncBoxes(this.rotations);
   },
   methods: {
     updateCount(event) {


### PR DESCRIPTION
When you declare `renderer` as a field in `data`, you are asking Vue to make it reactive. This leads to unnecessary conversions and getter/setter calls. Removing the field gives you the raw performance of Three.js. (which makes the point of this demo a bit moot, but for the sake of correctness...)

Also you can just use `mounted` instead of the nextTick inside `created` to get a hold of the ref.